### PR TITLE
perf(llm): 优化 HTTP客户端的写入缓冲区设置

### DIFF
--- a/jrag-server/src/main/java/io/github/jerryt92/jrag/service/llm/client/OllamaClient.java
+++ b/jrag-server/src/main/java/io/github/jerryt92/jrag/service/llm/client/OllamaClient.java
@@ -5,6 +5,8 @@ import io.github.jerryt92.jrag.model.ChatModel;
 import io.github.jerryt92.jrag.model.FunctionCallingModel;
 import io.github.jerryt92.jrag.model.ollama.OllamaModel;
 import io.github.jerryt92.jrag.model.ollama.OllamaOptions;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.WriteBufferWaterMark;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
@@ -29,7 +31,10 @@ public class OllamaClient extends LlmClient {
 
     public OllamaClient(LlmProperties llmProperties) {
         super(llmProperties);
-        this.webClient = WebClient.builder().clientConnector(new ReactorClientHttpConnector(HttpClient.create().protocol(HttpProtocol.HTTP11))).build();
+        this.webClient = WebClient.builder()
+                .clientConnector(new ReactorClientHttpConnector(HttpClient.create().protocol(HttpProtocol.HTTP11)))
+                .clientConnector(new ReactorClientHttpConnector(HttpClient.create().option(ChannelOption.WRITE_BUFFER_WATER_MARK, new WriteBufferWaterMark(1024 * 1024, 1024 * 1024 * 50))))
+                .build();
     }
 
     private final Set<SseEmitter> functionCallingSet = new HashSet<>();

--- a/jrag-server/src/main/java/io/github/jerryt92/jrag/service/llm/client/OpenAiClient.java
+++ b/jrag-server/src/main/java/io/github/jerryt92/jrag/service/llm/client/OpenAiClient.java
@@ -5,6 +5,8 @@ import com.alibaba.fastjson2.JSONObject;
 import io.github.jerryt92.jrag.config.LlmProperties;
 import io.github.jerryt92.jrag.model.ChatModel;
 import io.github.jerryt92.jrag.model.FunctionCallingModel;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.WriteBufferWaterMark;
 import org.springframework.ai.model.ModelOptionsUtils;
 import io.github.jerryt92.jrag.model.openai.OpenAIModel;
 import lombok.extern.slf4j.Slf4j;
@@ -31,11 +33,9 @@ public class OpenAiClient extends LlmClient {
 
     public OpenAiClient(LlmProperties llmProperties) {
         super(llmProperties);
-        this.webClient = WebClient.builder().clientConnector(
-                        new ReactorClientHttpConnector(
-                                HttpClient.create().protocol(HttpProtocol.HTTP11)
-                        )
-                )
+        this.webClient = WebClient.builder()
+                .clientConnector(new ReactorClientHttpConnector(HttpClient.create().protocol(HttpProtocol.HTTP11)))
+                .clientConnector(new ReactorClientHttpConnector(HttpClient.create().option(ChannelOption.WRITE_BUFFER_WATER_MARK, new WriteBufferWaterMark(1024 * 1024, 1024 * 1024 * 50))))
                 .baseUrl(llmProperties.openAiBaseUrl)
                 .defaultHeader("Authorization", "Bearer " + llmProperties.openAiKey)
                 .build();


### PR DESCRIPTION
- 在 OllamaClient 和 OpenAiClient 中添加了 WriteBufferWaterMark 配置
- 设置写入缓冲区低水位线为 1MB，高水位线为 50MB- 优化大文件传输性能，防止内存溢出