### PR TITLE
refactor(jrag): 优化聊天记录标题处理逻辑

### DIFF
--- a/jrag-server/src/main/java/io/github/jerryt92/jrag/model/Translator.java
+++ b/jrag-server/src/main/java/io/github/jerryt92/jrag/model/Translator.java
@@ -285,7 +285,7 @@ public final class Translator {
         chatContextRecord.setContextId(chatContextBo.getContextId());
         for (ChatModel.Message message : chatContextBo.getMessages()) {
             if (message.getRole().equals(ChatModel.Role.USER)) {
-                chatContextRecord.setTitle(message.getContent());
+                chatContextRecord.setTitle(message.getContent().length() > 64 ? message.getContent().substring(0, 64) : message.getContent());
                 break;
             }
         }


### PR DESCRIPTION
- 对用户消息的内容进行截取，作为聊天记录的标题
- 如果消息内容长度超过 64 个字符，则截取前 64个字符
- 此修改确保了聊天记录标题的一致性和可读性