### PR TITLE
docs:为 README 文件添加 GitHub 徽章

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# Jrag
+[English](README_en.md)
 
 [![GitHub](https://img.shields.io/badge/GitHub-Jrag-blue?logo=github)](https://github.com/jerryt92/jrag)
-
-[English](README_en.md)
 
 Jrag 是一个基于 Java Spring Boot 的 RAG（Retrieval-Augmented Generation）和MCP工具接入平台，旨在通过结合检索、MCP工具与生成式AI模型技术，增强大语言模型在 Java 生态中的应用能力。该平台支持接入多种主流的大语言模型接口，包括 Ollama 和 OpenAI，并集成了 Milvus 与 Redis 两种向量数据库，以提供高效的向量存储与检索服务。
 

--- a/README_en.md
+++ b/README_en.md
@@ -1,8 +1,6 @@
-# Jrag
+[简体中文](README.md)
 
 [![GitHub](https://img.shields.io/badge/GitHub-Jrag-blue?logo=github)](https://github.com/jerryt92/jrag)
-
-[简体中文](README.md)
 
 Jrag is a RAG (Retrieval-Augmented Generation) and MCP tool integration platform based on Java Spring Boot, designed to enhance the application capabilities of large language models within the Java ecosystem by combining retrieval, MCP tools, and generative AI model technologies. The platform supports integration with various mainstream large language model interfaces, including Ollama and OpenAI, and incorporates Milvus and Redis as vector databases to provide efficient vector storage and retrieval services.
 


### PR DESCRIPTION
- 在 README.md 和 README_en.md 文件的开头添加了 GitHub 徽章 -徽章链接指向 jerryt92/jrag GitHub 仓库
- 使用 blue 颜色方案，带有 GitHub logo