### PR TITLE
docs:优化 README 文件格式- 删除了 README.md 和 README_en.md 文件中的多余破折号- 保持了待完善功能…

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Jrag 是一个基于 Java Spring Boot 的 RAG（Retrieval-Augmented Generation�
 ## 待完善
 
 - **Rerank**：提供 Rerank 功能，以实现对检索结果的排序和过滤。
-- **适配MCP协议的Streamable HTTP传输层（等待Spring AI发布Release）。**
+- 适配MCP协议的Streamable HTTP传输层（等待Spring AI发布Release）。
 - **知识库维护**：提供知识库管理功能，支持知识库的创建、导入、导出、删除等操作。
 
 ## SQLite 初始化

--- a/README_en.md
+++ b/README_en.md
@@ -25,7 +25,7 @@ So far, most open-source RAG platforms are implemented in Python. As a Java deve
 ## To Be Improved
 
 - **Rerank**：Provide reranking capabilities to improve relevance.
-- **Streamable HTTP transport layer compatible with MCP protocol (awaiting Spring AI Release).**
+- Streamable HTTP transport layer compatible with MCP protocol (awaiting Spring AI Release).
 - **Knowledge Base Management**: Provide knowledge base management functions, supporting operations such as creation, import, export, and deletion of knowledge bases.
 
 ## SQLite Initialization


### PR DESCRIPTION
…列表的格式一致性